### PR TITLE
[nn.functional] defaults Optional params of batch_norm to None

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2479,8 +2479,8 @@ def _verify_batch_size(size: List[int]) -> None:
 
 def batch_norm(
     input: Tensor,
-    running_mean: Optional[Tensor],
-    running_var: Optional[Tensor],
+    running_mean: Optional[Tensor] = None,
+    running_var: Optional[Tensor] = None,
     weight: Optional[Tensor] = None,
     bias: Optional[Tensor] = None,
     training: bool = False,


### PR DESCRIPTION
The Optional parameters of functional batch_norm were not initialized to None even though it can be invoked without those values when training=True. Is there any reason to opt into this behaviour?

New typing is consistent with the type signature of functional instance_norm as well.

[torch/nn/functional.py#L2525-L2534](https://github.com/pytorch/pytorch/blob/e61aaab72562fe95d76e77b01678d71467e1739e/torch/nn/functional.py#L2525-L2534)
```python
def instance_norm(
    input: Tensor,
    running_mean: Optional[Tensor] = None,
    running_var: Optional[Tensor] = None,
    weight: Optional[Tensor] = None,
    bias: Optional[Tensor] = None,
    use_input_stats: bool = True,
    momentum: float = 0.1,
    eps: float = 1e-5,
) -> Tensor:
```
